### PR TITLE
Update to fix missing dependency

### DIFF
--- a/nexus-ruby-tools/pom.xml
+++ b/nexus-ruby-tools/pom.xml
@@ -96,7 +96,7 @@
       <plugin>
 	<groupId>de.saumya.mojo</groupId>
 	<artifactId>minitest-maven-plugin</artifactId>
-	<version>1.0.0-beta-SNAPSHOT</version>
+	<version>1.0.0-beta</version>
         <executions>
           <execution>
 	    <goals>


### PR DESCRIPTION
Updated nexus-ruby-tools POM to use released version of minitest-maven-plugin.
