### PR TITLE
Add synchronization on gemspec creation. Fixes deadlock.

### DIFF
--- a/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/DefaultRubygemsGateway.java
+++ b/nexus-ruby-tools/src/main/java/org/sonatype/nexus/ruby/DefaultRubygemsGateway.java
@@ -43,7 +43,7 @@ private JRubyScriptingContainer scriptingContainer;
     }
     
     @Override
-    public InputStream createGemspecRz( String gemname, InputStream gem )
+    public synchronized InputStream createGemspecRz( String gemname, InputStream gem )
     {
         try
         {


### PR DESCRIPTION
There was deadlock on gemspec creation for hosted repos. This _should_ fix it.
