### PR TITLE
NEXUS-5863: Attribute recursion fix

### DIFF
--- a/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/fs/RubyFSLocalRepositoryStorage.java
+++ b/nexus-ruby-plugin/src/main/java/org/sonatype/nexus/plugins/ruby/fs/RubyFSLocalRepositoryStorage.java
@@ -16,6 +16,7 @@ import javax.inject.Inject;
 
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.IOUtil;
+
 import org.sonatype.nexus.mime.MimeSupport;
 import org.sonatype.nexus.plugins.ruby.RubyGroupRepository;
 import org.sonatype.nexus.plugins.ruby.RubyRepository;
@@ -29,6 +30,7 @@ import org.sonatype.nexus.proxy.item.DefaultStorageFileItem;
 import org.sonatype.nexus.proxy.item.FileContentLocator;
 import org.sonatype.nexus.proxy.item.LinkPersister;
 import org.sonatype.nexus.proxy.item.PreparedContentLocator;
+import org.sonatype.nexus.proxy.item.RepositoryItemUid;
 import org.sonatype.nexus.proxy.item.StorageFileItem;
 import org.sonatype.nexus.proxy.item.StorageItem;
 import org.sonatype.nexus.proxy.repository.Repository;
@@ -58,7 +60,8 @@ public class RubyFSLocalRepositoryStorage extends DefaultFSLocalRepositoryStorag
     private ResourceStoreRequest fixPath(ResourceStoreRequest request)
     {
         // put the gems into subdirectory with first-letter of the gems name
-        request.setRequestPath( RubygemFile.fromFilename( request.getRequestPath() ).getPath() );
+        final File gemFile = RubygemFile.fromFilename( request.getRequestPath() );
+        request.setRequestPath( gemFile.getPath().replaceAll( "\\", RepositoryItemUid.PATH_SEPARATOR) );
         return request;
     }
 


### PR DESCRIPTION
Attribute recursion caused by OS native path separator.
Nexus, while (sadly) does not enforce/validate this, is strict regarding
paths and used path separators.

org.sonatype.nexus.proxy.item.RepositoryItemUid.PATH_SEPARATOR

Is the only separator it "recognizes" in any path occurrence.

This change fixed a "OS separator leak" occurring when Nexus
runs on Win OSes. In general, these constructs (passing in
java.io.File path directly to Nx path) should be avoided.

Issue:
https://issues.sonatype.org/browse/NEXUS-5863
